### PR TITLE
HistoryPusher now works with forms as well as links

### DIFF
--- a/jasmine/spec/hoochSpec.js
+++ b/jasmine/spec/hoochSpec.js
@@ -407,6 +407,25 @@ describe("hooch", function() {
       expect(new_path).toEqual([location.protocol,'//',location.host,location.pathname,'?','my_key=my_value'].join(''))
       delete history
     })
+    it('adds form data to the query string', function(){
+      var $form = affix('form[data-history-pusher="true"]')
+      var $input = $form.affix('input[type="text"][name="my_key"][value="my_value"]')
+      var $input = $form.affix('input[type="text"][name="my_key2"][value="my_value2"]')
+      var pusher = new hooch.HistoryPusher($form)
+      var new_state = null
+      var new_path = null
+      history = {
+        state: {},
+        replaceState: function(state, throwaway, newpath){
+          new_state = state
+          new_path = newpath
+        }
+      }
+      pusher.pushIt()
+      expect(new_state.my_key).toEqual('my_value')
+      expect(new_state.my_key2).toEqual('my_value2')
+      expect(new_path).toEqual([location.protocol,'//',location.host,location.pathname,'?','my_key=my_value&my_key2=my_value2'].join(''))
+    })
   })
   describe('HistoryReplacer', function(){
     it('replaces the path', function(){

--- a/lib/hooch/hooch_helper.rb
+++ b/lib/hooch/hooch_helper.rb
@@ -170,19 +170,19 @@ module Hooch
       end
     end
 
-    def history_pusher_attrs(key,value)
+    def history_pusher_attrs(key = nil,value = nil)
       ''.tap do |attrs|
         attrs.concat 'data-history-pusher=true'
-        attrs.concat " data-key=#{key}"
-        attrs.concat " data-value=\"#{value}\""
+        attrs.concat " data-key=#{key}" if key
+        attrs.concat " data-value=\"#{value}\"" if value
       end.html_safe
     end
 
-    def history_pusher(key,value)
+    def history_pusher(key = nil,value = nil)
       {}.tap do |params|
         params['data-history-pusher'] = true
-        params['data-key'] = key
-        params['data-value'] = value
+        params['data-key'] = key if key
+        params['data-value'] = value if value
       end
     end
 

--- a/lib/hooch/version.rb
+++ b/lib/hooch/version.rb
@@ -1,3 +1,3 @@
 module Hooch
-  VERSION = "0.13.2"
+  VERSION = "0.14.0"
 end

--- a/test/hooch_helper_test.rb
+++ b/test/hooch_helper_test.rb
@@ -157,6 +157,9 @@ class HoochHelperTest < ActionView::TestCase
   it "generates history pusher attrs" do
     attrs = history_pusher_attrs('my_key','my_value')
     attrs.must_equal 'data-history-pusher=true data-key=my_key data-value="my_value"'
+
+    form_attrs = history_pusher_attrs
+    form_attrs.must_equal 'data-history-pusher=true'
   end
 
   it "generates history_pusher params" do
@@ -164,6 +167,9 @@ class HoochHelperTest < ActionView::TestCase
     params["data-history-pusher"].must_equal true
     params["data-key"].must_equal 'my_key'
     params["data-value"].must_equal 'my_value'
+
+    form_params = history_pusher
+    form_params["data-history-pusher"].must_equal true
   end
 
   it "generates history replacer attrs" do


### PR DESCRIPTION
HistoryPusher for links works the same as it did before.

But now you can add it to a form and it will set all the form data on the query string when you submit.
